### PR TITLE
冒烟测试

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,13 +63,13 @@
 		<dependency>
 			<groupId>org.junit.jupiter</groupId>
 			<artifactId>junit-jupiter-api</artifactId>
-			<version>5.7.0</version>
+			<version>5.6.2</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.junit.jupiter</groupId>
 			<artifactId>junit-jupiter-engine</artifactId>
-			<version>5.7.0</version>
+			<version>5.6.2</version>
 			<scope>test</scope>
 		</dependency>
 

--- a/src/test/java/com/mushanwb/github/SmokeTest.java
+++ b/src/test/java/com/mushanwb/github/SmokeTest.java
@@ -1,0 +1,10 @@
+package com.mushanwb.github;
+
+import org.junit.jupiter.api.Test;
+
+public class SmokeTest {
+    @Test
+    public void test() {
+
+    }
+}


### PR DESCRIPTION
添加一个冒烟测试，结果运行的时候发现 jupiter maven 最新 5.7.0 版本会发出一个红色的警告，因此我将版本更改为 5.6.2